### PR TITLE
fix(capabilities): separate capability declarations from definitions

### DIFF
--- a/src/server/capabilities.ts
+++ b/src/server/capabilities.ts
@@ -1,222 +1,232 @@
+// Server capabilities - declares what the server supports
 export const capabilities = {
-  resources: {
-    get_components: {
-      description:
-        "List of available shadcn/ui components that can be used in the project",
-      uri: "resource:get_components",
-      contentType: "text/plain",
-    },
-    get_theme_metadata: {
-      description: "Get metadata for all available tweakcn themes",
-      uri: "resource:get_theme_metadata",
-      contentType: "application/json",
+  resources: {},
+  prompts: {},
+  tools: {},
+};
+
+// Resource definitions
+export const resourceDefinitions = {
+  get_components: {
+    description:
+      "List of available shadcn/ui components that can be used in the project",
+    uri: "resource:get_components",
+    contentType: "text/plain",
+  },
+  get_theme_metadata: {
+    description: "Get metadata for all available tweakcn themes",
+    uri: "resource:get_theme_metadata",
+    contentType: "application/json",
+  },
+};
+
+// Prompt definitions
+export const promptDefinitions = {
+  component_usage: {
+    description: "Get usage examples for a specific component",
+    arguments: {
+      componentName: {
+        type: "string",
+        description: "Name of the component to get usage for",
+      },
     },
   },
-  prompts: {
-    component_usage: {
-      description: "Get usage examples for a specific component",
-      arguments: {
+  component_search: {
+    description: "Search for components by name or description",
+    arguments: {
+      query: {
+        type: "string",
+        description: "Search query",
+      },
+    },
+  },
+  component_comparison: {
+    description: "Compare two components side by side",
+    arguments: {
+      component1: {
+        type: "string",
+        description: "First component name",
+      },
+      component2: {
+        type: "string",
+        description: "Second component name",
+      },
+    },
+  },
+  component_recommendation: {
+    description: "Get component recommendations based on use case",
+    arguments: {
+      useCase: {
+        type: "string",
+        description: "Use case description",
+      },
+    },
+  },
+  component_tutorial: {
+    description: "Get a step-by-step tutorial for using a component",
+    arguments: {
+      componentName: {
+        type: "string",
+        description: "Name of the component for tutorial",
+      },
+    },
+  },
+};
+
+// Tool definitions
+export const toolDefinitions = {
+  get_component: {
+    description:
+      "Get the source code for a specific shadcn/ui v4 component",
+    inputSchema: {
+      type: "object",
+      properties: {
         componentName: {
           type: "string",
-          description: "Name of the component to get usage for",
+          description:
+            'Name of the shadcn/ui component (e.g., "accordion", "button")',
         },
       },
+      required: ["componentName"],
     },
-    component_search: {
-      description: "Search for components by name or description",
-      arguments: {
-        query: {
-          type: "string",
-          description: "Search query",
-        },
-      },
-    },
-    component_comparison: {
-      description: "Compare two components side by side",
-      arguments: {
-        component1: {
-          type: "string",
-          description: "First component name",
-        },
-        component2: {
-          type: "string",
-          description: "Second component name",
-        },
-      },
-    },
-    component_recommendation: {
-      description: "Get component recommendations based on use case",
-      arguments: {
-        useCase: {
-          type: "string",
-          description: "Use case description",
-        },
-      },
-    },
-    component_tutorial: {
-      description: "Get a step-by-step tutorial for using a component",
-      arguments: {
+  },
+  get_component_demo: {
+    description:
+      "Get demo code illustrating how a shadcn/ui v4 component should be used",
+    inputSchema: {
+      type: "object",
+      properties: {
         componentName: {
           type: "string",
-          description: "Name of the component for tutorial",
+          description:
+            'Name of the shadcn/ui component (e.g., "accordion", "button")',
+        },
+      },
+      required: ["componentName"],
+    },
+  },
+  list_components: {
+    description: "Get all available shadcn/ui v4 components",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  get_component_metadata: {
+    description: "Get metadata for a specific shadcn/ui v4 component",
+    inputSchema: {
+      type: "object",
+      properties: {
+        componentName: {
+          type: "string",
+          description:
+            'Name of the shadcn/ui component (e.g., "accordion", "button")',
+        },
+      },
+      required: ["componentName"],
+    },
+  },
+  get_directory_structure: {
+    description:
+      "Get the directory structure of the shadcn-ui v4 repository",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path within the repository (default: v4 registry)",
+        },
+        owner: {
+          type: "string",
+          description: 'Repository owner (default: "shadcn-ui")',
+        },
+        repo: {
+          type: "string",
+          description: 'Repository name (default: "ui")',
+        },
+        branch: {
+          type: "string",
+          description: 'Branch name (default: "main")',
         },
       },
     },
   },
-  tools: {
-    get_component: {
-      description:
-        "Get the source code for a specific shadcn/ui v4 component",
-      inputSchema: {
-        type: "object",
-        properties: {
-          componentName: {
-            type: "string",
-            description:
-              'Name of the shadcn/ui component (e.g., "accordion", "button")',
-          },
+  get_block: {
+    description:
+      "Get source code for a specific shadcn/ui v4 block (e.g., calendar-01, dashboard-01)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        blockName: {
+          type: "string",
+          description:
+            'Name of the block (e.g., "calendar-01", "dashboard-01", "login-02")',
         },
-        required: ["componentName"],
-      },
-    },
-    get_component_demo: {
-      description:
-        "Get demo code illustrating how a shadcn/ui v4 component should be used",
-      inputSchema: {
-        type: "object",
-        properties: {
-          componentName: {
-            type: "string",
-            description:
-              'Name of the shadcn/ui component (e.g., "accordion", "button")',
-          },
-        },
-        required: ["componentName"],
-      },
-    },
-    list_components: {
-      description: "Get all available shadcn/ui v4 components",
-      inputSchema: {
-        type: "object",
-        properties: {},
-      },
-    },
-    get_component_metadata: {
-      description: "Get metadata for a specific shadcn/ui v4 component",
-      inputSchema: {
-        type: "object",
-        properties: {
-          componentName: {
-            type: "string",
-            description:
-              'Name of the shadcn/ui component (e.g., "accordion", "button")',
-          },
-        },
-        required: ["componentName"],
-      },
-    },
-    get_directory_structure: {
-      description:
-        "Get the directory structure of the shadcn-ui v4 repository",
-      inputSchema: {
-        type: "object",
-        properties: {
-          path: {
-            type: "string",
-            description: "Path within the repository (default: v4 registry)",
-          },
-          owner: {
-            type: "string",
-            description: 'Repository owner (default: "shadcn-ui")',
-          },
-          repo: {
-            type: "string",
-            description: 'Repository name (default: "ui")',
-          },
-          branch: {
-            type: "string",
-            description: 'Branch name (default: "main")',
-          },
+        includeComponents: {
+          type: "boolean",
+          description:
+            "Whether to include component files for complex blocks (default: true)",
         },
       },
+      required: ["blockName"],
     },
-    get_block: {
-      description:
-        "Get source code for a specific shadcn/ui v4 block (e.g., calendar-01, dashboard-01)",
-      inputSchema: {
-        type: "object",
-        properties: {
-          blockName: {
-            type: "string",
-            description:
-              'Name of the block (e.g., "calendar-01", "dashboard-01", "login-02")',
-          },
-          includeComponents: {
-            type: "boolean",
-            description:
-              "Whether to include component files for complex blocks (default: true)",
-          },
+  },
+  list_blocks: {
+    description:
+      "Get all available shadcn/ui v4 blocks with categorization",
+    inputSchema: {
+      type: "object",
+      properties: {
+        category: {
+          type: "string",
+          description:
+            "Filter by category (calendar, dashboard, login, sidebar, products)",
         },
-        required: ["blockName"],
-      },
-    },
-    list_blocks: {
-      description:
-        "Get all available shadcn/ui v4 blocks with categorization",
-      inputSchema: {
-        type: "object",
-        properties: {
-          category: {
-            type: "string",
-            description:
-              "Filter by category (calendar, dashboard, login, sidebar, products)",
-          },
-        },
-      },
-    },
-    // Tweakcn theme tools
-    get_tweakcn_presets: {
-      description: "Fetch available tweakcn theme presets (list)",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string", description: "Search keywords to filter presets" },
-        },
-      },
-    },
-    apply_tweakcn_theme: {
-      description:
-        "Apply a tweakcn theme preset to the project (writes CSS to global.css).",
-      inputSchema: {
-        type: "object",
-        properties: {
-          presetId: { type: "string", description: "ID of the preset to apply" },
-          query: { type: "string", description: "Search keywords to find a preset" },
-          tailwindVersion: { type: "string", description: "3 or 4", enum: ["3", "4"] },
-          cssPath: { type: "string", description: "Optional explicit path to global.css to write" },
-          dryRun: { type: "boolean", description: "If true, do not write files; just return preview" },
-        },
-        required: [],
-      },
-    },
-    list_themes: {
-      description: "List available tweakcn themes",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string", description: "Search query to filter themes" },
-        },
-      },
-    },
-    get_theme: {
-      description: "Get details of a specific tweakcn theme",
-      inputSchema: {
-        type: "object",
-        properties: {
-          themeName: { type: "string", description: "Name or ID of the theme to retrieve" },
-        },
-        required: ["themeName"],
       },
     },
   },
-}
+  // Tweakcn theme tools
+  get_tweakcn_presets: {
+    description: "Fetch available tweakcn theme presets (list)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search keywords to filter presets" },
+      },
+    },
+  },
+  apply_tweakcn_theme: {
+    description:
+      "Apply a tweakcn theme preset to the project (writes CSS to global.css).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presetId: { type: "string", description: "ID of the preset to apply" },
+        query: { type: "string", description: "Search keywords to find a preset" },
+        tailwindVersion: { type: "string", description: "3 or 4", enum: ["3", "4"] },
+        cssPath: { type: "string", description: "Optional explicit path to global.css to write" },
+        dryRun: { type: "boolean", description: "If true, do not write files; just return preview" },
+      },
+      required: [],
+    },
+  },
+  list_themes: {
+    description: "List available tweakcn themes",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query to filter themes" },
+      },
+    },
+  },
+  get_theme: {
+    description: "Get details of a specific tweakcn theme",
+    inputSchema: {
+      type: "object",
+      properties: {
+        themeName: { type: "string", description: "Name or ID of the theme to retrieve" },
+      },
+      required: ["themeName"],
+    },
+  },
+};


### PR DESCRIPTION
# fix(capabilities): separate capability declarations from definitions

## Summary

- Split the MCP `capabilities` declaration from the detailed definitions to satisfy the MCP SDK types and fix a TypeScript compile error.

## What I changed

- **File**: capabilities.ts — replaced the single mixed `capabilities` object with:
  - `capabilities` (declaration-only: `{ resources: {}, prompts: {}, tools: {} }`)
  - `resourceDefinitions` (detailed resource metadata)
  - `promptDefinitions` (detailed prompt metadata)
  - `toolDefinitions` (detailed tool metadata)

## Why

- The MCP SDK expects `capabilities` to only declare supported categories (e.g., that prompts are supported); providing full prompt definitions in `capabilities` caused a type mismatch and a TS compilation error. Separating declarations from definitions keeps detailed metadata available for handlers while satisfying the SDK types.

## Verification

- Ran build locally: `pnpm build` — TypeScript compiles with no errors.

## How to test

```bash
# from repository root
pnpm install
pnpm build
# optionally run any existing test script if present
pnpm test
```

## Notes for reviewers

- This is a refactor that preserves all previous data but moves detailed definitions to named exports. Server initialization and handlers can import the detailed definitions (e.g., `promptDefinitions`) and register them with the server as-needed.
- The change is safe and limited to one file; no runtime behavior is modified besides how definitions are exported.
- Branch: `fix/capabilities-separate-definitions` → target `master`