### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -111,6 +111,10 @@ export const setupHandlers = (server: Server): void => {
               },
               required: ['componentName'],
             },
+            annotations: {
+              title: "Get Component",
+              readOnlyHint: true,
+            },
           },
           {
             name: 'get_component_demo',
@@ -125,6 +129,10 @@ export const setupHandlers = (server: Server): void => {
               },
               required: ['componentName'],
             },
+            annotations: {
+              title: "Get Component Demo",
+              readOnlyHint: true,
+            },
           },
           {
             name: 'list_components',
@@ -132,6 +140,10 @@ export const setupHandlers = (server: Server): void => {
             inputSchema: {
               type: 'object',
               properties: {},
+            },
+            annotations: {
+              title: "List Components",
+              readOnlyHint: true,
             },
           },
           {
@@ -146,6 +158,10 @@ export const setupHandlers = (server: Server): void => {
                 },
               },
               required: ['componentName'],
+            },
+            annotations: {
+              title: "Get Component Metadata",
+              readOnlyHint: true,
             },
           },
           {
@@ -172,6 +188,10 @@ export const setupHandlers = (server: Server): void => {
                 },
               },
             },
+            annotations: {
+              title: "Get Directory Structure",
+              readOnlyHint: true,
+            },
           },
           {
             name: 'get_block',
@@ -190,6 +210,10 @@ export const setupHandlers = (server: Server): void => {
               },
               required: ['blockName'],
             },
+            annotations: {
+              title: "Get Block",
+              readOnlyHint: true,
+            },
           },
           {
             name: 'list_blocks',
@@ -202,6 +226,10 @@ export const setupHandlers = (server: Server): void => {
                   description: 'Filter by category (calendar, dashboard, login, sidebar, products)',
                 },
               },
+            },
+            annotations: {
+              title: "List Blocks",
+              readOnlyHint: true,
             },
           },
           {
@@ -229,6 +257,10 @@ export const setupHandlers = (server: Server): void => {
                 },
               },
             },
+            annotations: {
+              title: "Apply Theme",
+              destructiveHint: true,
+            },
           },
           {
             name: 'list_themes',
@@ -236,6 +268,10 @@ export const setupHandlers = (server: Server): void => {
             inputSchema: {
               type: 'object',
               properties: {},
+            },
+            annotations: {
+              title: "List Themes",
+              readOnlyHint: true,
             },
           },
           {
@@ -250,6 +286,10 @@ export const setupHandlers = (server: Server): void => {
                 },
               },
               required: ['themeName'],
+            },
+            annotations: {
+              title: "Get Theme",
+              readOnlyHint: true,
             },
           },
         ];


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 10 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to 9 read-only tools:
  - `get_component` - fetches component source code
  - `get_component_demo` - fetches demo code
  - `list_components` - lists available components
  - `get_component_metadata` - fetches component metadata
  - `get_directory_structure` - fetches repository structure
  - `get_block` - fetches block source code
  - `list_blocks` - lists available blocks
  - `list_themes` - lists TweakCN themes
  - `get_theme` - fetches theme details

- Added `destructiveHint: true` to `apply_theme` (writes files to filesystem)

- Added `title` annotations for human-readable display

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- MCP clients can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- Clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] Server builds successfully (`npm run build`)
- [x] TypeScript compilation passes (no errors)
- [x] **Live verification:** Started server and confirmed `tools/list` returns annotations for all 10 tools
- [x] Annotation values correctly match tool behavior (read-only vs destructive)

## Verification Output

```
Total tools: 10

Tool Name                      Title                     ReadOnly   Destructive
---------------------------------------------------------------------------
get_component                  Get Component             True       N/A       
get_component_demo             Get Component Demo        True       N/A       
list_components                List Components           True       N/A       
get_component_metadata         Get Component Metadata    True       N/A       
get_directory_structure        Get Directory Structure   True       N/A       
get_block                      Get Block                 True       N/A       
list_blocks                    List Blocks               True       N/A       
apply_theme                    Apply Theme               N/A        True      
list_themes                    List Themes               True       N/A       
get_theme                      Get Theme                 True       N/A       
```

## Before/After

**Before:**
```typescript
{
  name: 'get_component',
  description: 'Get the source code for a specific shadcn/ui v4 component',
  inputSchema: { ... },
}
```

**After:**
```typescript
{
  name: 'get_component',
  description: 'Get the source code for a specific shadcn/ui v4 component',
  inputSchema: { ... },
  annotations: {
    title: "Get Component",
    readOnlyHint: true,
  },
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)