### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,8 @@ MIT License - see [LICENSE](LICENSE) for details.
 **Made with ❤️ by [Janardhan Polle](https://github.com/Jpisnice)**
 
 **Star ⭐ this repo if you find it helpful!**
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jpisnice-shadcn-ui-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jpisnice-shadcn-ui-mcp-server)